### PR TITLE
[cmake] make velocypack an imported library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ if(VELOCYPACK_SOURCE_DIR)
     add_subdirectory(${VELOCYPACK_SOURCE_DIR} ./vpack-build)
     set(VELOCYPACK_LIBRARIES velocypack)
 else()
-    include(FindVelocypack)
     find_package(Velocypack)
 
     if (NOT ${VELOCYPACK_FOUND})
@@ -74,7 +73,7 @@ if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
 endif()
 
 target_link_libraries(fuerte PUBLIC
-    ${VELOCYPACK_LIBRARIES}
+    arangodb::velocypack
     ${CURL_LIBRARIES}
     ${Boost_LIBRARIES}
     ${OPENSSL_LIBRARIES}

--- a/cmake/Modules/FindVelocypack.cmake
+++ b/cmake/Modules/FindVelocypack.cmake
@@ -1,14 +1,17 @@
 # FindVelocypack
 # --------
 #
-# Find ArangoDB Velocypack
-#
-# ::
+# Find ArangoDB Velocypack::
 #
 #   VELOCYPACK_INCLUDE_DIRS   - where to find velocypack/vpack.h, etc.
 #   VELOCYPACK_LIBRARIES      - List of libraries when using velocypack.
 #   VELOCYPACK_FOUND          - True if velocypack found.
 #   VELOCYPACK_VERSION_STRING - the version of velocypack found (since CMake 2.8.8)
+#
+# Import target::
+#
+#   arangodb::velocypack
+#
 
 # Look for the header file.
 find_path(VELOCYPACK_INCLUDE_DIR NAMES velocypack/vpack.h)
@@ -38,6 +41,12 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS(VELOCYPACK
                                   VERSION_VAR VELOCYPACK_VERSION_STRING)
 
 if(VELOCYPACK_FOUND)
+  add_library(arangodb::velocypack IMPORTED STATIC GLOBAL)
+  set_target_properties(arangodb::velocypack
+      PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGE CXX
+                 IMPORTED_LOCATION "${VELOCYPACK_LIBRARY}"
+                 INTERFACE_INCLUDE_DIRECTORIES "${VELOCYPACK_INCLUDE_DIR}")
+
   set(VELOCYPACK_LIBRARIES ${VELOCYPACK_LIBRARY})
   set(VELOCYPACK_INCLUDE_DIRS ${VELOCYPACK_INCLUDE_DIR})
 endif()


### PR DESCRIPTION
On systems with velocypack installed in a non-default location, the include directory for velocypack as detected by the `FindVelocypack.cmake` module was not added to the include path for the `fuerte` library target.

With this change the `FindVelocypack.cmake` module provides an imported library target as recommended by modern CMake providing all required information to link against it including include path.